### PR TITLE
Replace hardcoded developer button label with translated string in landscape about screen

### DIFF
--- a/app/src/main/res/layout-land/fragment_about.xml
+++ b/app/src/main/res/layout-land/fragment_about.xml
@@ -65,7 +65,7 @@
 		style="?android:attr/buttonStyleSmall"
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
-		android:text="Developer"
+		android:text="@string/dev"
 		android:id="@+id/dev"
 		android:onClick="btnDev_clicked"
 		android:layout_alignParentBottom="true"


### PR DESCRIPTION
The default layout uses the translated string already but the landscape version doesn't.