### PR TITLE
Add comprehensive unit tests for MainActivity and About activities

### DIFF
--- a/app/src/test/java/be/robinj/rot13/AboutRobolectricTest.java
+++ b/app/src/test/java/be/robinj/rot13/AboutRobolectricTest.java
@@ -1,0 +1,89 @@
+package be.robinj.rot13;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.fakes.RoboMenu;
+import org.robolectric.shadows.ShadowActivity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Robolectric tests for the About screen: they inflate the real layout, verify
+ * the version label is populated from the package metadata and that the
+ * developer button fires a browser intent.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AboutRobolectricTest {
+
+	@Test
+	public void launchInflatesLayoutAndAddsPlaceholderFragment() {
+		try (ActivityController<About> controller =
+				 Robolectric.buildActivity(About.class).setup()) {
+			About activity = controller.get();
+			assertNotNull(activity);
+
+			activity.getSupportFragmentManager().executePendingTransactions();
+			Fragment fragment = activity.getSupportFragmentManager().findFragmentById(R.id.container);
+			assertNotNull("PlaceholderFragment should be added to the container", fragment);
+			assertTrue(fragment instanceof About.PlaceholderFragment);
+		}
+	}
+
+	@Test
+	public void versionLabelIsResolvedFromPackageInfo() {
+		try (ActivityController<About> controller =
+				 Robolectric.buildActivity(About.class).setup()) {
+			About activity = controller.get();
+			activity.getSupportFragmentManager().executePendingTransactions();
+
+			TextView version = activity.findViewById(R.id.version);
+			String text = version.getText().toString();
+
+			// The code prefixes the resolved version name with "v"; the
+			// "{...}" form only appears when the package can't be found.
+			assertTrue("version should start with 'v' but was: " + text, text.startsWith("v"));
+			assertTrue("package metadata should resolve without error: " + text,
+					!text.startsWith("{"));
+		}
+	}
+
+	@Test
+	public void developerButtonOpensTheDeveloperWebsite() {
+		try (ActivityController<About> controller =
+				 Robolectric.buildActivity(About.class).setup()) {
+			About activity = controller.get();
+
+			View dev = activity.findViewById(R.id.dev);
+			assertNotNull("developer button should be present", dev);
+			activity.btnDev_clicked(dev);
+
+			ShadowActivity shadow = Shadows.shadowOf(activity);
+			Intent started = shadow.getNextStartedActivity();
+			assertNotNull("clicking developer should start an activity", started);
+			assertEquals(Intent.ACTION_VIEW, started.getAction());
+			assertEquals(Uri.parse("http://www.robinj.be/"), started.getData());
+		}
+	}
+
+	@Test
+	public void onCreateOptionsMenuReturnsTrue() {
+		try (ActivityController<About> controller =
+				 Robolectric.buildActivity(About.class).setup()) {
+			About activity = controller.get();
+			assertTrue(activity.onCreateOptionsMenu(new RoboMenu(activity)));
+		}
+	}
+}

--- a/app/src/test/java/be/robinj/rot13/MainActivityRobolectricTest.java
+++ b/app/src/test/java/be/robinj/rot13/MainActivityRobolectricTest.java
@@ -2,6 +2,7 @@ package be.robinj.rot13;
 
 import android.content.Intent;
 import android.view.MenuItem;
+import android.widget.TextView;
 
 import androidx.fragment.app.Fragment;
 
@@ -11,10 +12,12 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.fakes.RoboMenu;
 import org.robolectric.fakes.RoboMenuItem;
 import org.robolectric.shadows.ShadowActivity;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -53,6 +56,104 @@ public class MainActivityRobolectricTest {
 			Intent started = shadow.getNextStartedActivity();
 			assertNotNull("selecting About should start an activity", started);
 			assertEquals(About.class.getName(), started.getComponent().getClassName());
+		}
+	}
+
+	@Test
+	public void onCreateOptionsMenuInflatesTheAboutItem() {
+		try (ActivityController<MainActivity> controller =
+				 Robolectric.buildActivity(MainActivity.class).setup()) {
+			MainActivity activity = controller.get();
+
+			RoboMenu menu = new RoboMenu(activity);
+			assertTrue(activity.onCreateOptionsMenu(menu));
+			assertNotNull("About item should be inflated into the menu",
+					menu.findItem(R.id.action_about));
+		}
+	}
+
+	@Test
+	public void unhandledMenuItemIsDelegatedToSuper() {
+		try (ActivityController<MainActivity> controller =
+				 Robolectric.buildActivity(MainActivity.class).setup()) {
+			MainActivity activity = controller.get();
+
+			// An id the activity does not recognise must fall through to the
+			// AppCompat superclass, which reports it as unhandled.
+			assertFalse(activity.onOptionsItemSelected(new RoboMenuItem(0)));
+		}
+	}
+
+	@Test
+	public void typingPlaintextLiveEncodesIntoTheRot13Field() {
+		try (ActivityController<MainActivity> controller =
+				 Robolectric.buildActivity(MainActivity.class).setup()) {
+			MainActivity activity = controller.get();
+
+			TextView txtPlain = activity.findViewById(R.id.txtPlain);
+			TextView txtRot13 = activity.findViewById(R.id.txtRot13);
+
+			assertTrue("plaintext field should take focus", txtPlain.requestFocus());
+			txtPlain.setText("Hello, World!");
+
+			assertEquals("Uryyb, Jbeyq!", txtRot13.getText().toString());
+		}
+	}
+
+	@Test
+	public void typingCiphertextLiveDecodesIntoThePlaintextField() {
+		try (ActivityController<MainActivity> controller =
+				 Robolectric.buildActivity(MainActivity.class).setup()) {
+			MainActivity activity = controller.get();
+
+			TextView txtPlain = activity.findViewById(R.id.txtPlain);
+			TextView txtRot13 = activity.findViewById(R.id.txtRot13);
+
+			assertTrue("ciphertext field should take focus", txtRot13.requestFocus());
+			txtRot13.setText("Uryyb, Jbeyq!");
+
+			assertEquals("Hello, World!", txtPlain.getText().toString());
+		}
+	}
+
+	@Test
+	public void editingAnUnfocusedFieldDoesNotOverwriteTheOther() {
+		try (ActivityController<MainActivity> controller =
+				 Robolectric.buildActivity(MainActivity.class).setup()) {
+			MainActivity activity = controller.get();
+
+			TextView txtPlain = activity.findViewById(R.id.txtPlain);
+			TextView txtRot13 = activity.findViewById(R.id.txtRot13);
+
+			// Give focus to the ciphertext field, then mutate the (unfocused)
+			// plaintext field programmatically. The listener is gated on
+			// hasFocus(), so the ciphertext must stay put.
+			assertTrue(txtRot13.requestFocus());
+			txtRot13.setText("Purpx");
+			txtPlain.setText("ignored");
+
+			assertEquals("Purpx", txtRot13.getText().toString());
+		}
+	}
+
+	@Test
+	public void editingClearsAnyErrorMarkersOnBothFields() {
+		try (ActivityController<MainActivity> controller =
+				 Robolectric.buildActivity(MainActivity.class).setup()) {
+			MainActivity activity = controller.get();
+
+			TextView txtPlain = activity.findViewById(R.id.txtPlain);
+			TextView txtRot13 = activity.findViewById(R.id.txtRot13);
+
+			txtPlain.setError("boom");
+			txtRot13.setError("boom");
+
+			assertTrue(txtPlain.requestFocus());
+			txtPlain.setText("reset");
+
+			// beforeTextChanged wipes the error state on both fields.
+			assertEquals(null, txtPlain.getError());
+			assertEquals(null, txtRot13.getError());
 		}
 	}
 }

--- a/app/src/test/java/be/robinj/rot13/Rot13Test.java
+++ b/app/src/test/java/be/robinj/rot13/Rot13Test.java
@@ -3,6 +3,7 @@ package be.robinj.rot13;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class Rot13Test {
 
@@ -68,5 +69,99 @@ public class Rot13Test {
         // n and a are the critical boundary chars for each half of the alphabet
         assertEquals("an", MainActivity.rotate("na"));
         assertEquals("AN", MainActivity.rotate("NA"));
+    }
+
+    @Test
+    public void everyLowercaseLetterShiftsByThirteen() {
+        // Each of the 26 letters must map to the letter 13 positions further
+        // along, wrapping around the alphabet.
+        for (int i = 0; i < 26; i++) {
+            char in = (char) ('a' + i);
+            char expected = (char) ('a' + ((i + 13) % 26));
+            assertEquals("rotate('" + in + "')",
+                    String.valueOf(expected), MainActivity.rotate(String.valueOf(in)));
+        }
+    }
+
+    @Test
+    public void everyUppercaseLetterShiftsByThirteen() {
+        for (int i = 0; i < 26; i++) {
+            char in = (char) ('A' + i);
+            char expected = (char) ('A' + ((i + 13) % 26));
+            assertEquals("rotate('" + in + "')",
+                    String.valueOf(expected), MainActivity.rotate(String.valueOf(in)));
+        }
+    }
+
+    @Test
+    public void singleLetterBoundaries() {
+        // The four corners of each 13-letter half.
+        assertEquals("n", MainActivity.rotate("a"));
+        assertEquals("z", MainActivity.rotate("m"));
+        assertEquals("a", MainActivity.rotate("n"));
+        assertEquals("m", MainActivity.rotate("z"));
+        assertEquals("N", MainActivity.rotate("A"));
+        assertEquals("Z", MainActivity.rotate("M"));
+        assertEquals("A", MainActivity.rotate("N"));
+        assertEquals("M", MainActivity.rotate("Z"));
+    }
+
+    @Test
+    public void charactersAdjacentToLettersAreUnchanged() {
+        // The ASCII characters immediately outside the A-Z / a-z ranges must
+        // never be shifted: '@'(64) before 'A', '['(91) after 'Z',
+        // '`'(96) before 'a', '{'(123) after 'z'.
+        assertEquals("@[`{", MainActivity.rotate("@[`{"));
+    }
+
+    @Test
+    public void whitespaceIsPreserved() {
+        // Spaces, tabs and newlines separating letters must survive intact.
+        assertEquals("uryyb\tjbeyq", MainActivity.rotate("hello\tworld"));
+        assertEquals("n o\tp\nq", MainActivity.rotate("a b\tc\nd"));
+    }
+
+    @Test
+    public void unicodeCharactersAreUnchanged() {
+        // Accented and non-Latin characters fall outside the ASCII letter
+        // ranges and must pass through untouched.
+        assertEquals("Pnsé ñ 你好", MainActivity.rotate("Café ñ 你好"));
+    }
+
+    @Test
+    public void digitsInterspersedWithLetters() {
+        assertEquals("n1o2p3", MainActivity.rotate("a1b2c3"));
+    }
+
+    @Test
+    public void isSelfInverseAcrossPrintableAscii() {
+        // Applying ROT13 twice to every printable ASCII character must yield
+        // the identity, and a single application must actually change the
+        // letters (i.e. it is not a no-op).
+        StringBuilder sb = new StringBuilder();
+        for (char c = 32; c < 127; c++) {
+            sb.append(c);
+        }
+        String original = sb.toString();
+        String once = MainActivity.rotate(original);
+        assertEquals(original, MainActivity.rotate(once));
+        // A single application must genuinely transform the input (the 52
+        // letters shift), so it is not a silent pass-through.
+        assertNotEquals(original, once);
+    }
+
+    @Test
+    public void longTextRoundTrips() {
+        String original =
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                        + "The five boxing wizards jump quickly! 0123456789";
+        assertEquals(original, MainActivity.rotate(MainActivity.rotate(original)));
+    }
+
+    @Test
+    public void knownCiphertextPair() {
+        // "Why did the chicken cross the road?" is a classic ROT13 sample.
+        assertEquals("Jul qvq gur puvpxra pebff gur ebnq?",
+                MainActivity.rotate("Why did the chicken cross the road?"));
     }
 }


### PR DESCRIPTION
## Summary
This PR adds extensive test coverage for the ROT13 application, including unit tests for the rotation algorithm and Robolectric integration tests for both the MainActivity and About activities.

## Key Changes

### Rot13Test.java
- Added 9 new test cases covering edge cases and comprehensive validation of the ROT13 algorithm:
  - `everyLowercaseLetterShiftsByThirteen()` - validates all 26 lowercase letters shift correctly
  - `everyUppercaseLetterShiftsByThirteen()` - validates all 26 uppercase letters shift correctly
  - `singleLetterBoundaries()` - tests the four corner cases (a↔n, m↔z for both cases)
  - `charactersAdjacentToLettersAreUnchanged()` - ensures ASCII boundaries (@, [, `, {) are preserved
  - `whitespaceIsPreserved()` - validates tabs and newlines survive encoding
  - `unicodeCharactersAreUnchanged()` - confirms non-ASCII characters pass through untouched
  - `digitsInterspersedWithLetters()` - tests digit preservation
  - `isSelfInverseAcrossPrintableAscii()` - verifies double application returns original and single application changes letters
  - `longTextRoundTrips()` - tests a longer realistic text sample
  - `knownCiphertextPair()` - validates against the classic "Why did the chicken cross the road?" example

### MainActivityRobolectricTest.java
- Added 5 new Robolectric integration tests:
  - `onCreateOptionsMenuInflatesTheAboutItem()` - verifies the About menu item is properly inflated
  - `unhandledMenuItemIsDelegatedToSuper()` - ensures unrecognized menu items delegate to superclass
  - `typingPlaintextLiveEncodesIntoTheRot13Field()` - tests live encoding as user types plaintext
  - `typingCiphertextLiveDecodesIntoThePlaintextField()` - tests live decoding as user types ciphertext
  - `editingAnUnfocusedFieldDoesNotOverwriteTheOther()` - validates that programmatic changes to unfocused fields don't trigger listeners
  - `editingClearsAnyErrorMarkersOnBothFields()` - confirms error states are cleared on text changes
- Added imports for `TextView`, `RoboMenu`, and `assertFalse`

### AboutRobolectricTest.java (new file)
- Created comprehensive test suite for the About activity with 4 test cases:
  - `launchInflatesLayoutAndAddsPlaceholderFragment()` - verifies layout inflation and fragment attachment
  - `versionLabelIsResolvedFromPackageInfo()` - validates version string is properly resolved from package metadata
  - `developerButtonOpensTheDeveloperWebsite()` - confirms the developer button launches the correct browser intent
  - `onCreateOptionsMenuReturnsTrue()` - verifies menu creation returns true

## Notable Implementation Details
- All tests use try-with-resources for proper ActivityController cleanup
- Tests validate both positive cases (correct behavior) and edge cases (boundary conditions)
- The ROT13 tests comprehensively cover the algorithm's self-inverse property and character handling
- UI tests verify both programmatic and user-initiated text changes work correctly
- Tests use Robolectric's shadow objects to verify intents and menu inflation without requiring a real device

https://claude.ai/code/session_01XJDWe7Zm8fK4bBxd3M927C